### PR TITLE
Fix Open API V1 data path and transient cloud failures

### DIFF
--- a/custom_components/growatt_server/coordinator.py
+++ b/custom_components/growatt_server/coordinator.py
@@ -183,6 +183,20 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             min_energy = self.api.min_energy(self.device_id)
 
             min_info = {**min_details, **min_settings, **min_energy}
+
+            # tlx_last_data returns epvTotal but no epvToday, which leaves the
+            # "solar generation today" sensor unknown for the whole life of the
+            # entity. The per-string epv{1..4}Today values are present, so add
+            # the missing total up from them.
+            if min_info.get("epvToday") is None:
+                strings = [
+                    _as_float(min_info[key])
+                    for key in ("epv1Today", "epv2Today", "epv3Today", "epv4Today")
+                    if min_info.get(key) is not None
+                ]
+                if strings and None not in strings:
+                    min_info["epvToday"] = round(sum(strings), 2)
+
             self.data = min_info
             _LOGGER.debug("min_info for device %s: %r", self.device_id, min_info)
         elif self.device_type == "sph":

--- a/custom_components/growatt_server/coordinator.py
+++ b/custom_components/growatt_server/coordinator.py
@@ -133,6 +133,7 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # The V1 Plant APIs do not provide the same information as the classic plant_info() API
                 # More specifically:
                 # 1. There is no monetary information to be found, so today and lifetime money is not available
+                #    (the money sensors are therefore not created at all on V1, see sensor/__init__.py)
                 # This means, for the total coordinator we fetch and map the following:
                 # todayEnergy -> today_energy
                 # totalEnergy -> total_energy

--- a/custom_components/growatt_server/coordinator.py
+++ b/custom_components/growatt_server/coordinator.py
@@ -9,6 +9,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 import growattServer
+from requests import RequestException
 
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
@@ -32,6 +33,18 @@ if TYPE_CHECKING:
 type GrowattConfigEntry = ConfigEntry[GrowattRuntimeData]
 
 SCAN_INTERVAL = datetime.timedelta(minutes=5)
+
+# The Growatt cloud drops requests fairly regularly (connection resets, read
+# timeouts, the odd 502 or DNS blip). Failing the update on the very first one
+# turns every entity of the plant unavailable for a full poll cycle, so serve
+# the cached data for a couple of attempts and only give up once the failures
+# persist.
+MAX_TRANSIENT_FAILURES = 3
+
+# V1 Open API error codes that mean "you called this endpoint again too soon".
+# Each endpoint allows one call per 5 minutes; a restart landing inside that
+# window is enough to trigger it, and the next poll goes through normally.
+RATE_LIMIT_ERROR_CODES = {10011, 10012}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,6 +94,7 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.plant_id = plant_id
         self.previous_values: dict[str, Any] = {}
         self._pre_reset_values: dict[str, float] = {}
+        self._consecutive_failures = 0
 
         # Use the shared API instance from runtime_data (already logged in for Classic API)
         self.api = config_entry.runtime_data.api
@@ -125,24 +139,22 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         elif self.device_type == "inverter":
             self.data = self.api.inverter_detail(self.device_id)
         elif self.device_type == "min":
-            # Open API V1: min device
-            try:
-                min_details = self.api.min_detail(self.device_id)
-                min_settings = self.api.min_settings(self.device_id)
-                min_energy = self.api.min_energy(self.device_id)
-            except growattServer.GrowattV1ApiError as err:
-                raise UpdateFailed(f"Error fetching min device data: {err}") from err
+            # Open API V1: min device.
+            # GrowattV1ApiError is deliberately left to propagate: it is handled
+            # centrally in _async_update_data, which can tell a routine rate
+            # limit apart from a real API failure.
+            min_details = self.api.min_detail(self.device_id)
+            min_settings = self.api.min_settings(self.device_id)
+            min_energy = self.api.min_energy(self.device_id)
 
             min_info = {**min_details, **min_settings, **min_energy}
             self.data = min_info
             _LOGGER.debug("min_info for device %s: %r", self.device_id, min_info)
         elif self.device_type == "sph":
-            # Open API V1: SPH device (single-phase hybrid)
-            try:
-                sph_detail = self.api.sph_detail(self.device_id)
-                sph_energy = self.api.sph_energy(self.device_id)
-            except growattServer.GrowattV1ApiError as err:
-                raise UpdateFailed(f"Error fetching SPH device data: {err}") from err
+            # Open API V1: SPH device (single-phase hybrid).
+            # As for "min", GrowattV1ApiError is handled in _async_update_data.
+            sph_detail = self.api.sph_detail(self.device_id)
+            sph_energy = self.api.sph_energy(self.device_id)
 
             combined = {**sph_detail, **sph_energy}
 
@@ -280,10 +292,30 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 _LOGGER.error("Re-login exception: %s", err)
                 return False
 
+    def _serve_cached_or_fail(self, err: Exception, reason: str) -> dict[str, Any]:
+        """Ride out a transient failure on cached data, or give up on it.
+
+        Growatt's cloud fails often enough that treating every hiccup as an
+        outage makes the entities flap; keep the previous reading for the first
+        few consecutive failures and only surface UpdateFailed once they stop
+        looking transient.
+        """
+        self._consecutive_failures += 1
+        if self.data and self._consecutive_failures < MAX_TRANSIENT_FAILURES:
+            _LOGGER.warning(
+                "%s (attempt %s/%s), keeping last known data: %s",
+                reason,
+                self._consecutive_failures,
+                MAX_TRANSIENT_FAILURES,
+                err,
+            )
+            return self.data
+        raise UpdateFailed(f"{reason}: {err}") from err
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Asynchronously update data via library."""
         try:
-            return await self.hass.async_add_executor_job(self._sync_update_data)
+            data = await self.hass.async_add_executor_job(self._sync_update_data)
         except json.decoder.JSONDecodeError as err:
             # Session expired — server returned HTML login page instead of JSON
             if self.api_version == "classic":
@@ -295,14 +327,37 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
                 if await self._async_re_login():
                     try:
-                        return await self.hass.async_add_executor_job(
+                        data = await self.hass.async_add_executor_job(
                             self._sync_update_data
                         )
                     except json.decoder.JSONDecodeError as retry_err:
                         raise UpdateFailed(
                             f"Data fetch failed after re-login: {retry_err}"
                         ) from retry_err
+                    else:
+                        self._consecutive_failures = 0
+                        return data
             raise UpdateFailed(f"Error fetching data: {err}") from err
+        except growattServer.GrowattV1ApiError as err:
+            # GrowattV1ApiError is not a RequestException, so anything that does
+            # not catch it explicitly escapes the coordinator as an "Unexpected
+            # error" traceback and gets treated as a bug in the integration
+            # rather than as a retryable API failure. Rate limiting in
+            # particular is routine, not exceptional.
+            if getattr(err, "error_code", None) in RATE_LIMIT_ERROR_CODES:
+                return self._serve_cached_or_fail(
+                    err, f"Growatt API rate limit hit for {self.device_id}"
+                )
+            raise UpdateFailed(
+                f"Growatt API error fetching {self.device_id}: {err}"
+            ) from err
+        except (RequestException, TimeoutError) as err:
+            return self._serve_cached_or_fail(
+                err, f"Transient error fetching {self.device_id}"
+            )
+        else:
+            self._consecutive_failures = 0
+            return data
 
     def get_currency(self):
         """Get the currency."""

--- a/custom_components/growatt_server/coordinator.py
+++ b/custom_components/growatt_server/coordinator.py
@@ -49,6 +49,21 @@ RATE_LIMIT_ERROR_CODES = {10011, 10012}
 _LOGGER = logging.getLogger(__name__)
 
 
+def _as_float(value: Any) -> float | None:
+    """Coerce an API value to float, or None when it isn't numeric.
+
+    The V1 API is inconsistent about types - the same field comes back as an
+    int, a float or a decimal string depending on the endpoint, and empty
+    strings are used for "no value".
+    """
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator to manage Growatt data fetching.
 
@@ -118,15 +133,35 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # The V1 Plant APIs do not provide the same information as the classic plant_info() API
                 # More specifically:
                 # 1. There is no monetary information to be found, so today and lifetime money is not available
-                # 2. There is no nominal power, this is provided by inverter min_energy()
-                # This means, for the total coordinator we can only fetch and map the following:
+                # This means, for the total coordinator we fetch and map the following:
                 # todayEnergy -> today_energy
                 # totalEnergy -> total_energy
                 # invTodayPpv -> current_power
+                # nominalPower -> peak_power_actual
                 total_info = self.api.plant_energy_overview(self.plant_id)
                 total_info["todayEnergy"] = total_info["today_energy"]
                 total_info["totalEnergy"] = total_info["total_energy"]
                 total_info["invTodayPpv"] = total_info["current_power"]
+
+                # plant/data does carry the plant's nominal power, in kW, under
+                # peak_power_actual. The classic plant_info() reports nominalPower
+                # in W, which is what the sensor is declared as, so scale it.
+                # Without this the "maximum output" sensor stays unknown forever.
+                nominal_power = _as_float(total_info.get("peak_power_actual"))
+                if nominal_power is not None:
+                    total_info["nominalPower"] = nominal_power * 1000
+
+                # current_power is regularly pinned at 0 by the Growatt cloud even
+                # when the plant is demonstrably producing (verified against
+                # /v1/plant/power, which reported kW-level output for the very same
+                # minute plant/data returned 0). The per-device coordinators do get
+                # a live AC figure, so fall back to summing those - that data is
+                # already fetched, so this costs no extra call against the
+                # one-request-per-5-minutes limit.
+                if not _as_float(total_info["invTodayPpv"]):
+                    device_power = self._sum_device_output_power()
+                    if device_power is not None:
+                        total_info["invTodayPpv"] = device_power
             else:
                 # Classic API: use plant_info as before
                 total_info = self.api.plant_info(self.device_id)
@@ -233,6 +268,22 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
 
         return self.data
+
+    def _sum_device_output_power(self) -> float | None:
+        """Return the plant's AC output as the sum of its inverters' `pac`.
+
+        Used as a fallback for the total coordinator when the plant endpoint
+        reports no current power. Returns None when no device has reported a
+        usable value yet - notably on the first refresh after a restart, where
+        the total coordinator runs before the device coordinators.
+        """
+        devices = getattr(self.config_entry.runtime_data, "devices", None) or {}
+        total: float | None = None
+        for coordinator in devices.values():
+            power = _as_float((coordinator.data or {}).get("pac"))
+            if power is not None:
+                total = power if total is None else total + power
+        return total
 
     async def _async_re_login(self) -> bool:
         """Attempt to re-login to the Growatt API when session expires (Classic API only).

--- a/custom_components/growatt_server/manifest.json
+++ b/custom_components/growatt_server/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/johanzander/growatt_server_upstream/issues",
   "loggers": ["growattServer"],
   "requirements": ["growattServer==1.9.0"],
-  "version": "2.5.0"
+  "version": "2.5.1"
 }

--- a/custom_components/growatt_server/sensor/__init__.py
+++ b/custom_components/growatt_server/sensor/__init__.py
@@ -34,8 +34,16 @@ async def async_setup_entry(
 
     entities: list[GrowattSensor] = []
 
-    # Add total sensors
+    # Add total sensors.
+    # The V1 Open API has no monetary data anywhere in the plant endpoints, so
+    # the currency-based sensors would sit at "unknown" for the entire life of
+    # the entity. Only create them for the classic API, which does report money.
     total_coordinator = data.total_coordinator
+    total_sensor_types = [
+        description
+        for description in TOTAL_SENSOR_TYPES
+        if not (description.currency and total_coordinator.api_version == "v1")
+    ]
     entities.extend(
         GrowattSensor(
             total_coordinator,
@@ -44,7 +52,7 @@ async def async_setup_entry(
             unique_id=f"{config_entry.data['plant_id']}-{description.key}",
             description=description,
         )
-        for description in TOTAL_SENSOR_TYPES
+        for description in total_sensor_types
     )
 
     # Add sensors for each device

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -583,3 +583,69 @@ async def test_non_rate_limit_api_error_fails_immediately(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_total_nominal_power_from_peak_power_actual(
+    hass: HomeAssistant,
+    mock_growatt_v1_api,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the plant's maximum power comes from peak_power_actual on V1.
+
+    The V1 plant endpoint has no nominalPower field, but it does report the
+    plant's nominal power in kW as peak_power_actual.
+    """
+    mock_growatt_v1_api.plant_energy_overview.return_value = {
+        "today_energy": 12.5,
+        "total_energy": 1250.0,
+        "current_power": 2500,
+        "peak_power_actual": 12,
+    }
+
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.test_plant_total_maximum_power")
+    assert state is not None
+    assert state.state == "12000.0"
+
+
+async def test_total_output_power_falls_back_to_devices(
+    hass: HomeAssistant,
+    mock_growatt_v1_api,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test plant output power is summed from the inverters when the plant reports 0.
+
+    The Growatt cloud regularly returns current_power = 0 while the inverters
+    themselves report AC output.
+    """
+    mock_growatt_v1_api.device_list.return_value = {
+        "devices": [
+            {"device_sn": "MIN123456", "type": 7},
+            {"device_sn": "MIN654321", "type": 7},
+        ]
+    }
+    mock_growatt_v1_api.plant_energy_overview.return_value = {
+        "today_energy": 12.5,
+        "total_energy": 1250.0,
+        "current_power": 0,
+    }
+    mock_growatt_v1_api.min_detail.return_value = {
+        "deviceSn": "MIN123456",
+        "pac": 745.5,
+    }
+
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    # The total coordinator does its first refresh before the devices have any
+    # data, so the fallback only has something to sum from the next poll on.
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.test_plant_total_output_power")
+    assert state is not None
+    assert state.state == "1491.0"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -695,3 +695,34 @@ async def test_solar_generation_today_prefers_api_value(
     state = hass.states.get("sensor.min123456_solar_energy_today")
     assert state is not None
     assert state.state == "7.5"
+
+
+async def test_money_sensors_not_created_on_v1(
+    hass: HomeAssistant,
+    mock_growatt_v1_api,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the currency sensors are skipped on V1, which has no monetary data."""
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("sensor.test_plant_total_money_lifetime") is None
+    assert hass.states.get("sensor.test_plant_total_total_money_today") is None
+    # ... while the rest of the total sensors are still there
+    assert hass.states.get("sensor.test_plant_total_energy_today") is not None
+
+
+async def test_money_sensors_created_on_classic(
+    hass: HomeAssistant,
+    mock_growatt_classic_api,
+    mock_config_entry_classic: MockConfigEntry,
+) -> None:
+    """Test the currency sensors still exist on the classic API, which reports money."""
+    mock_growatt_classic_api.device_list.return_value = [
+        {"deviceSn": "TLX123456", "deviceType": "tlx"}
+    ]
+
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry_classic)
+
+    assert hass.states.get("sensor.test_plant_total_total_money_today") is not None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from freezegun.api import FrozenDateTimeFactory
 import growattServer
 import pytest
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import STATE_UNAVAILABLE, Platform
@@ -473,3 +474,112 @@ async def test_total_sensors_classic_api(
     await snapshot_platform(
         hass, entity_registry, snapshot, mock_config_entry_classic.entry_id
     )
+
+
+async def test_rate_limit_keeps_last_known_data(
+    hass: HomeAssistant,
+    mock_growatt_v1_api,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a rate-limited poll keeps the previous reading instead of dropping it.
+
+    One call per endpoint per 5 minutes is a routine condition, not an outage.
+    """
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    entity_id = "sensor.test_plant_total_energy_today"
+    assert hass.states.get(entity_id).state == "12.5"
+
+    mock_growatt_v1_api.plant_energy_overview.side_effect = (
+        growattServer.GrowattV1ApiError(
+            "Error during getting plant energy overview",
+            error_code=10012,
+            error_msg="error_frequently_access",
+        )
+    )
+
+    # The first couple of hits ride it out on the cached value...
+    for _ in range(2):
+        freezer.tick(timedelta(minutes=5))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert hass.states.get(entity_id).state == "12.5"
+
+    # ...and only a persistent failure marks the entity unavailable.
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+
+async def test_transient_network_error_keeps_last_known_data(
+    hass: HomeAssistant,
+    mock_growatt_v1_api,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a dropped connection doesn't immediately flip the entities unavailable."""
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    entity_id = "sensor.test_plant_total_energy_today"
+    assert hass.states.get(entity_id).state == "12.5"
+
+    mock_growatt_v1_api.plant_energy_overview.side_effect = RequestsConnectionError(
+        "('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))"
+    )
+
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert hass.states.get(entity_id).state == "12.5"
+
+    # A recovery resets the tolerance, so the next blip is ridden out too.
+    mock_growatt_v1_api.plant_energy_overview.side_effect = None
+    mock_growatt_v1_api.plant_energy_overview.return_value = {
+        "today_energy": 13.0,
+        "total_energy": 1250.0,
+        "current_power": 2500,
+    }
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert hass.states.get(entity_id).state == "13.0"
+
+    mock_growatt_v1_api.plant_energy_overview.side_effect = RequestsConnectionError(
+        "Connection reset by peer"
+    )
+    for _ in range(2):
+        freezer.tick(timedelta(minutes=5))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert hass.states.get(entity_id).state == "13.0"
+
+
+async def test_non_rate_limit_api_error_fails_immediately(
+    hass: HomeAssistant,
+    mock_growatt_v1_api,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a real API error is surfaced at once rather than hidden behind the cache."""
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    entity_id = "sensor.test_plant_total_energy_today"
+    assert hass.states.get(entity_id).state == "12.5"
+
+    mock_growatt_v1_api.plant_energy_overview.side_effect = (
+        growattServer.GrowattV1ApiError(
+            "Error during getting plant energy overview",
+            error_code=10002,
+            error_msg="device serial number is empty",
+        )
+    )
+
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -649,3 +649,49 @@ async def test_total_output_power_falls_back_to_devices(
     state = hass.states.get("sensor.test_plant_total_output_power")
     assert state is not None
     assert state.state == "1491.0"
+
+
+async def test_solar_generation_today_derived_from_strings(
+    hass: HomeAssistant,
+    mock_growatt_v1_api,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test epvToday is added up from the per-string values when absent.
+
+    tlx_last_data returns epvTotal but no epvToday, which otherwise leaves the
+    sensor unknown forever.
+    """
+    mock_growatt_v1_api.min_energy.return_value = {
+        "epvTotal": 4997.1,
+        "epv1Today": 0.5,
+        "epv2Today": 0.5,
+        "epv3Today": 0.5,
+        "epv4Today": 0.5,
+    }
+
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.min123456_solar_energy_today")
+    assert state is not None
+    assert state.state == "2.0"
+
+
+async def test_solar_generation_today_prefers_api_value(
+    hass: HomeAssistant,
+    mock_growatt_v1_api,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a real epvToday from the API is never overwritten by the derived sum."""
+    mock_growatt_v1_api.min_energy.return_value = {
+        "epvToday": 7.5,
+        "epv1Today": 0.5,
+        "epv2Today": 0.5,
+    }
+
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.min123456_solar_energy_today")
+    assert state is not None
+    assert state.state == "7.5"


### PR DESCRIPTION
## Problem

Running the integration against a real token-authenticated plant (Open API V1, five MIN inverters, ~12 kWp) surfaced three separate problems.

**API errors came out as tracebacks.** `GrowattV1ApiError` derives from `GrowattError`, not `RequestException`, so nothing in `_async_update_data` caught it. Every API-level failure showed up as `Unexpected error fetching growatt_server (<sn>) data` with a full traceback — reported as a bug in the integration rather than as a retryable API failure.

**A single transient cloud failure blanked the whole plant.** 13 days of logs: 17 connection resets, 3 timeouts, 2 remote disconnects, 1 502 and 1 DNS failure. Each one left every entity of the plant `unavailable` until the next poll five minutes later. The API's own rate limit (one call per endpoint per 5 minutes, `error_code 10012`) has the same effect, and a restart landing inside that window is enough to trigger it.

**Four sensors could never hold a value on V1:**

- `total_maximum_output` — unknown forever. The comment in the coordinator says V1 has no nominal power, but `plant/data` does report it, as `peak_power_actual`, in kW (observed 12, against `peak_power` of 12.2 kW from `plant/details`).
- `total_output_power` — pinned at 0 W. `plant/data` returns `current_power: 0` even with a fresh `last_update_time` while the plant is producing: for the very minute it returned 0, `/v1/plant/power` reported 419 W and each of the five inverters reported 217.9 W of `pac`.
- `tlx_solar_generation_today` — unknown forever. `tlx_last_data` returns `epvTotal` but has no `epvToday` field.
- `total_money_today` and `total_money_total` — unknown forever. No V1 plant endpoint exposes monetary data at all.

## Solution

Four commits, one per concern:

- **Coordinator error handling.** `GrowattV1ApiError` is now handled centrally in `_async_update_data`, which also makes the local `try/except` in the `min` and `sph` branches unnecessary. Rate limits (`10011`/`10012`) and network failures (`RequestException`, `TimeoutError`) keep the last known data for up to `MAX_TRANSIENT_FAILURES` (3) consecutive failures before raising `UpdateFailed`. An API error that isn't a rate limit still fails straight away.
- **Plant nominal power and output power.** `nominalPower` is mapped from `peak_power_actual` (kW → W). When `current_power` is 0 or missing, plant power falls back to the sum of the devices' `pac` — data the device coordinators have already fetched, so it costs no extra call against the rate limit.
- **Derived `epvToday`.** Since the field isn't in the response, it is summed from `epv1Today` through `epv4Today`. A real `epvToday` from the API is never overwritten.
- **Currency sensors on classic only.** They are no longer created when `api_version == "v1"`. Worth flagging: for existing V1 users the two entities become orphans in the registry and have to be removed by hand. That seemed better than leaving them unknown forever, but this commit can be dropped on its own if you'd rather keep them.

## Files changed

- `coordinator.py` — `_serve_cached_or_fail()`, `_sum_device_output_power()`, `_as_float()` helper, exception handling in `_async_update_data()`, V1 mapping in the `total` branch and the `epvToday` derivation in the `min` branch
- `sensor/__init__.py` — filter the currency sensors by API version
- `manifest.json` — version bump to 2.5.1
- `tests/test_sensor.py` — 9 tests, one per item above

## Test plan

`master` on its own already fails 9 snapshot tests against the Home Assistant version I ran here. With these changes it is exactly the same 9 failures plus the 9 new tests passing (124 passed) — no regressions. I deliberately left the snapshots alone so that churn doesn't get mixed into this PR.

In production, on a plant with five MIN inverters and token auth: maximum output went from unknown to 12000 W, output power from 0 W to 6259.7 W (the inverters summed to 6409.7 W at that same moment — the gap is sampling skew between the plant coordinator and the device coordinators), solar generation today from unknown to 2.4 kWh on each inverter, and the 95 inverter entities ended up with no unknown or unavailable states.
